### PR TITLE
Help command

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -1,0 +1,25 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type helpCmd struct {
+}
+
+var (
+	descriptions = []string{
+		"dokkoi help - Displays all of the help commands that this bot knows about.",
+		"dokkoi echo <text> - Reply back with <text>",
+		"dokkoi echo <query> - Queries Google Images for <query> and returns a top result.",
+		"<name>++ - Increment score for a name",
+		"<name>-- - Decrement score for a name",
+	}
+)
+
+func (c *helpCmd) SendMessage(s *discordgo.Session, channelID string) error {
+	_, err := s.ChannelMessageSend(channelID, strings.Join(descriptions, "\n"))
+	return err
+}

--- a/command/help.go
+++ b/command/help.go
@@ -11,7 +11,7 @@ type helpCmd struct {
 }
 
 var descriptions = map[string]string{
-	"help":  "dokkoi help - Displays all of the help commands that this bot knows about.",
+	"help":  "dokkoi help - Displays all of the help commands that this bot knows about.\ndokkoi help <query> - Displays all help commands that match <query>.",
 	"echo":  "dokkoi echo <text> - Reply back with <text>",
 	"image": "dokkoi image <query> - Queries Google Images for <query> and returns a top result.",
 	"++":    "<name>++ - Increment score for a name",

--- a/command/help.go
+++ b/command/help.go
@@ -7,19 +7,31 @@ import (
 )
 
 type helpCmd struct {
+	target string
 }
 
-var (
-	descriptions = []string{
-		"dokkoi help - Displays all of the help commands that this bot knows about.",
-		"dokkoi echo <text> - Reply back with <text>",
-		"dokkoi echo <query> - Queries Google Images for <query> and returns a top result.",
-		"<name>++ - Increment score for a name",
-		"<name>-- - Decrement score for a name",
-	}
-)
+var descriptions = map[string]string{
+	"help":  "dokkoi help - Displays all of the help commands that this bot knows about.",
+	"echo":  "dokkoi echo <text> - Reply back with <text>",
+	"image": "dokkoi image <query> - Queries Google Images for <query> and returns a top result.",
+	"++":    "<name>++ - Increment score for a name",
+	"--":    "<name>-- - Decrement score for a name",
+}
 
 func (c *helpCmd) SendMessage(s *discordgo.Session, channelID string) error {
-	_, err := s.ChannelMessageSend(channelID, strings.Join(descriptions, "\n"))
+	var desc string
+	if c.target == "" {
+		desc = strings.Join(values(descriptions), "\n")
+	} else {
+		desc = descriptions[c.target]
+	}
+	_, err := s.ChannelMessageSend(channelID, desc)
 	return err
+}
+
+func values(m map[string]string) (s []string) {
+	for _, v := range m {
+		s = append(s, v)
+	}
+	return
 }

--- a/command/service.go
+++ b/command/service.go
@@ -50,6 +50,12 @@ func (s *service) GetCommand(content string) DokkoiCmd {
 		return nil
 	}
 	switch cmd[1] {
+	case "help":
+		// return helpCmd only in the case of  'dokkoi help' was sent as of now.
+		if len(cmd) == 2 {
+			return &helpCmd{}
+		}
+		return nil
 	case "echo":
 		return &echoCmd{message: strings.Join(cmd[2:], " ")}
 	case "image":

--- a/command/service.go
+++ b/command/service.go
@@ -29,6 +29,25 @@ type DokkoiCmd interface {
 }
 
 func (s *service) GetCommand(content string) DokkoiCmd {
+	// replace full-width whitespace to half size whitespace
+	replacedContent := strings.Replace(content, "　", " ", -1)
+	cmd := strings.Split(replacedContent, " ")
+	if (len(cmd) <= 1 || cmd[0] != "dokkoi") && !(strings.HasSuffix(content, IncrOperator) || strings.HasSuffix(content, DecrOperator)) {
+		return nil
+	}
+	switch cmd[1] {
+	case "help":
+		return &helpCmd{target: strings.Join(cmd[2:], " ")}
+	case "echo":
+		return &echoCmd{message: strings.Join(cmd[2:], " ")}
+	case "image":
+		return &imageCmd{
+			customSearchRepo: s.customSearchRepo,
+			query:            strings.Join(cmd[2:], " "),
+		}
+	}
+
+	// check score command
 	if strings.HasSuffix(content, IncrOperator) {
 		return &scoreCmd{
 			scoreRepo: s.scoreRepo,
@@ -42,28 +61,5 @@ func (s *service) GetCommand(content string) DokkoiCmd {
 			operator:  DecrOperator,
 		}
 	}
-
-	// replace full-width whitespace to half size whitespace
-	replacedContent := strings.Replace(content, "　", " ", -1)
-	cmd := strings.Split(replacedContent, " ")
-	if len(cmd) <= 1 || cmd[0] != "dokkoi" {
-		return nil
-	}
-	switch cmd[1] {
-	case "help":
-		// return helpCmd only in the case of  'dokkoi help' was sent as of now.
-		if len(cmd) == 2 {
-			return &helpCmd{}
-		}
-		return nil
-	case "echo":
-		return &echoCmd{message: strings.Join(cmd[2:], " ")}
-	case "image":
-		return &imageCmd{
-			customSearchRepo: s.customSearchRepo,
-			query:            strings.Join(cmd[2:], " "),
-		}
-	default:
-		return nil
-	}
+	return nil
 }

--- a/command/service.go
+++ b/command/service.go
@@ -32,34 +32,29 @@ func (s *service) GetCommand(content string) DokkoiCmd {
 	// replace full-width whitespace to half size whitespace
 	replacedContent := strings.Replace(content, "　", " ", -1)
 	cmd := strings.Split(replacedContent, " ")
-	if (len(cmd) <= 1 || cmd[0] != "dokkoi") && !(strings.HasSuffix(content, IncrOperator) || strings.HasSuffix(content, DecrOperator)) {
-		return nil
-	}
-	switch cmd[1] {
-	case "help":
+	switch {
+	case len(cmd) >= 2 && cmd[1] == "help":
 		return &helpCmd{target: strings.Join(cmd[2:], " ")}
-	case "echo":
+	case len(cmd) >= 3 && cmd[1] == "echo":
 		return &echoCmd{message: strings.Join(cmd[2:], " ")}
-	case "image":
+	case len(cmd) >= 3 && cmd[1] == "image":
 		return &imageCmd{
 			customSearchRepo: s.customSearchRepo,
 			query:            strings.Join(cmd[2:], " "),
 		}
-	}
-
-	// check score command
-	if strings.HasSuffix(content, IncrOperator) {
+	case strings.HasSuffix(content, IncrOperator):
 		return &scoreCmd{
 			scoreRepo: s.scoreRepo,
 			user:      content[:len(content)-2],
 			operator:  IncrOperator,
 		}
-	} else if strings.HasSuffix(content, DecrOperator) {
+	case strings.HasSuffix(content, DecrOperator):
 		return &scoreCmd{
 			scoreRepo: s.scoreRepo,
 			user:      content[:len(content)-2],
 			operator:  DecrOperator,
 		}
+	default:
+		return nil
 	}
-	return nil
 }

--- a/command/service_test.go
+++ b/command/service_test.go
@@ -21,7 +21,7 @@ func TestService_GetCommand(t *testing.T) {
 		},
 		"help and other": {
 			content:  "dokkoi help image",
-			expected: nil,
+			expected: &helpCmd{target: "image"},
 		},
 		"echo": {
 			content:  "dokkoi echo hoge",

--- a/command/service_test.go
+++ b/command/service_test.go
@@ -15,6 +15,14 @@ func TestService_GetCommand(t *testing.T) {
 			content:  "work",
 			expected: nil,
 		},
+		"help": {
+			content:  "dokkoi help",
+			expected: &helpCmd{},
+		},
+		"help and other": {
+			content:  "dokkoi help image",
+			expected: nil,
+		},
 		"echo": {
 			content:  "dokkoi echo hoge",
 			expected: &echoCmd{message: "hoge"},


### PR DESCRIPTION
fix: #8 

## Overview
I implemented `dokkoi help command`.
this command returns some descriptions of commands.

in addition, i changed to use a switch statement for getting a command in all cases, for decrease empty message errors occurrences like below.
> Cannot send an empty message

## Example
if you say 'dokkoi help`, dokkoi returns a message as below .
```
dokkoi help - Displays all of the help commands that this bot knows about.
dokkoi help <query> - Displays all help commands that match <query>.
dokkoi echo <text> - Reply back with <text>
dokkoi image <query> - Queries Google Images for <query> and returns a top result.
<name>++ - Increment score for a name
<name>-- - Decrement score for a name
```

furthermore, if you say `dokkoi help echo`, dokkoi returns a description of `dokkoi echo` command.
`dokkoi echo <text> - Reply back with <text>`