### PR TITLE
check redisCli is not nil before closing

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,5 +89,7 @@ func main() {
 
 	// close connections clearly
 	dg.Close()
-	redisCli.Close()
+	if redisCli != nil {
+		redisCli.Close()
+	}
 }


### PR DESCRIPTION
## Description
redisCli is always closed even in the case of dokkoi doesn't use a redis, and it cause to panic.
so, I added a if statement check redisCli is not nil before closing it.

## Checks
- [ ] Did you add some new commands?
    - [ ] You added descriptions to the help command.
    - [ ] You added test cases to the `service_test.go`.
